### PR TITLE
Fix Discord link for Opus

### DIFF
--- a/data/opus.json
+++ b/data/opus.json
@@ -13,7 +13,7 @@
     "careers": "https://www.lindylabs.net/",
     "twitter": "https://twitter.com/OpusMoney",
     "telegram": "",
-    "discord": "https://discord.gg/RqRMhZmP",
+    "discord": "https://discord.gg/K8QdxShe",
     "github": "https://github.com/lindy-labs",
     "youtube": "",
     "medium": "https://medium.com/aura-protocol",


### PR DESCRIPTION
The existing Discord invite link expired and is now compromised. This PR fixes the Discord invite link.