### PR TITLE
fix: chainId in signMessage

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/src/sections/DappPage/DappPageRating.tsx
+++ b/src/sections/DappPage/DappPageRating.tsx
@@ -83,7 +83,6 @@ const DappPageRating = ({ dappKey = "my_dapp" }: Props) => {
     }
     ratingValue++
     if (connectedWallet && connectedWallet.isConnected) {
-      const chainId = determineIfMainnet() ? "SN_MAIN" : "SN_GOERLI"
       const signature = await connectedWallet.account.signMessage({
         message: {
           dappKey: dappKey,
@@ -91,7 +90,7 @@ const DappPageRating = ({ dappKey = "my_dapp" }: Props) => {
         },
         domain: {
           name: "Dappland",
-          chainId,
+          chainId: connectedWallet.chainId,
           version: "1.0",
         },
         types: {


### PR DESCRIPTION
prevent  `is not Hex or decimal` exception using wallet chainId